### PR TITLE
Fix: Android - Empty space at the bottom of the screen in some devices.

### DIFF
--- a/src/components/TourOverlay.tsx
+++ b/src/components/TourOverlay.tsx
@@ -9,7 +9,7 @@ import { useTour } from '../hooks/useTour';
 import type { InternalTourContextType } from '../types';
 import { DEFAULT_ZONE_STYLE } from '../constants/defaults';
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
 const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedView = Animated.View as unknown as ComponentType<any>;

--- a/src/components/TourProvider.tsx
+++ b/src/components/TourProvider.tsx
@@ -40,7 +40,7 @@ import {
   clearTourProgress,
 } from '../utils/storage';
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
 /**
  * Computes the zone geometry based on element bounds and zone style.

--- a/src/components/TourTooltip.tsx
+++ b/src/components/TourTooltip.tsx
@@ -20,7 +20,7 @@ import type {
 } from '../types';
 import { DEFAULT_LABELS } from '../constants/defaults';
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
 const getDynamicStyles = (tooltipStyles?: TooltipStyles) => {
   const defaultStyles = {

--- a/src/components/TourZone.tsx
+++ b/src/components/TourZone.tsx
@@ -25,7 +25,7 @@ import type {
   CardProps,
 } from '../types';
 
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
 const AnimatedView = Animated.View as unknown as ComponentType<any>;
 


### PR DESCRIPTION
Getting screen height instead of window height as it was causing blank space at the bottom of screen in some android devices.