### PR TITLE
fix: keep tooltip inside viewport when neither side fits the target

### DIFF
--- a/src/__tests__/tooltipPlacement.test.ts
+++ b/src/__tests__/tooltipPlacement.test.ts
@@ -1,0 +1,63 @@
+import {
+  getTooltipTop,
+  TOOLTIP_EDGE_MARGIN,
+  TOOLTIP_TARGET_GAP,
+} from '../utils/tooltipPlacement';
+
+const SCREEN_HEIGHT = 640;
+const TOOLTIP_HEIGHT = 180;
+
+describe('getTooltipTop', () => {
+  it('places the tooltip below a target near the top of the screen', () => {
+    // Header icon: plenty of room below.
+    const top = getTooltipTop(40, 44, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe(40 + 44 + TOOLTIP_TARGET_GAP);
+  });
+
+  it('places the tooltip above a target near the bottom of the screen', () => {
+    // FAB: plenty of room above.
+    const top = getTooltipTop(560, 56, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe(560 - TOOLTIP_HEIGHT - TOOLTIP_TARGET_GAP);
+  });
+
+  it('centers the tooltip on screen when the target is too tall for either side', () => {
+    // The reported bug: a 400px tall card starting near the top leaves
+    // no room above or below, so the tooltip rendered off-screen bottom.
+    const targetY = 143;
+    const targetHeight = 400;
+
+    // Sanity check: both sides genuinely overflow in this setup.
+    expect(targetY - TOOLTIP_HEIGHT - TOOLTIP_TARGET_GAP).toBeLessThan(
+      TOOLTIP_EDGE_MARGIN
+    );
+    expect(
+      targetY + targetHeight + TOOLTIP_TARGET_GAP + TOOLTIP_HEIGHT
+    ).toBeGreaterThan(SCREEN_HEIGHT - TOOLTIP_EDGE_MARGIN);
+
+    const top = getTooltipTop(
+      targetY,
+      targetHeight,
+      TOOLTIP_HEIGHT,
+      SCREEN_HEIGHT
+    );
+    expect(top).toBe((SCREEN_HEIGHT - TOOLTIP_HEIGHT) / 2);
+  });
+
+  it('keeps the tooltip fully inside the viewport when centered', () => {
+    const top = getTooltipTop(143, 400, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBeGreaterThanOrEqual(TOOLTIP_EDGE_MARGIN);
+    expect(top + TOOLTIP_HEIGHT).toBeLessThanOrEqual(
+      SCREEN_HEIGHT - TOOLTIP_EDGE_MARGIN
+    );
+  });
+
+  it('falls back to the opposite side when the preferred side overflows', () => {
+    // Heuristic wants "below" (target top-half) but below overflows while
+    // above fits: target lower than usual with a small tooltip.
+    // targetY=250, height=200, tooltip=120 on 640 screen:
+    // below top = 470, 470+120=590 <= 628 fits... so force overflow:
+    // targetY=250, height=360 → below top = 630 → overflow; above top = 110 → fits.
+    const top = getTooltipTop(250, 360, 120, SCREEN_HEIGHT);
+    expect(top).toBe(250 - 120 - TOOLTIP_TARGET_GAP);
+  });
+});

--- a/src/components/TourTooltip.tsx
+++ b/src/components/TourTooltip.tsx
@@ -19,6 +19,7 @@ import type {
   TooltipStyles,
 } from '../types';
 import { DEFAULT_LABELS } from '../constants/defaults';
+import { getTooltipTop } from '../utils/tooltipPlacement';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
@@ -135,13 +136,6 @@ export const TourTooltip = memo(() => {
       Extrapolation.CLAMP
     );
 
-    const spaceAbove = safeTargetY;
-    const spaceBelow = SCREEN_HEIGHT - (safeTargetY + safeTargetHeight);
-
-    const shouldPlaceAbove =
-      (spaceAbove > spaceBelow && spaceAbove > safeTooltipHeight + 30) ||
-      (safeTargetY > SCREEN_HEIGHT / 2 && spaceAbove > safeTooltipHeight + 20);
-
     const horizontalCenter = safeTargetX + safeTargetWidth / 2;
     const left = horizontalCenter - tooltipWidth / 2;
 
@@ -159,13 +153,13 @@ export const TourTooltip = memo(() => {
       transform: [{ translateY: interpolate(activeOpacity, [0, 1], [10, 0]) }],
     };
 
-    if (shouldPlaceAbove) {
-      style.top = Math.max(10, safeTargetY - safeTooltipHeight - 20);
-      style.bottom = undefined;
-    } else {
-      style.top = safeTargetY + safeTargetHeight + 20;
-      style.bottom = undefined;
-    }
+    style.top = getTooltipTop(
+      safeTargetY,
+      safeTargetHeight,
+      safeTooltipHeight,
+      SCREEN_HEIGHT
+    );
+    style.bottom = undefined;
 
     return style;
   });

--- a/src/utils/tooltipPlacement.ts
+++ b/src/utils/tooltipPlacement.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure placement math for the tour tooltip.
+ * Kept separate from TourTooltip so it can be unit-tested
+ * and called from the Reanimated worklet (hence the 'worklet' directive).
+ */
+
+/** Minimum distance from the screen edges. */
+export const TOOLTIP_EDGE_MARGIN = 12;
+/** Vertical gap between the highlighted target and the tooltip. */
+export const TOOLTIP_TARGET_GAP = 20;
+
+/**
+ * Computes the `top` position for the tooltip.
+ *
+ * Preference order:
+ * 1. The side (above/below the target) chosen by the existing heuristic.
+ * 2. The opposite side, if the preferred side would overflow the viewport.
+ * 3. Vertically centered on screen, when neither side fits
+ *    (e.g. the highlighted element is too tall and there is no room
+ *    above or below without rendering off-screen).
+ */
+export const getTooltipTop = (
+  targetY: number,
+  targetHeight: number,
+  tooltipHeight: number,
+  screenHeight: number
+): number => {
+  'worklet';
+
+  const spaceAbove = targetY;
+  const spaceBelow = screenHeight - (targetY + targetHeight);
+
+  const shouldPlaceAbove =
+    (spaceAbove > spaceBelow && spaceAbove > tooltipHeight + 30) ||
+    (targetY > screenHeight / 2 && spaceAbove > tooltipHeight + 20);
+
+  const aboveTop = targetY - tooltipHeight - TOOLTIP_TARGET_GAP;
+  const belowTop = targetY + targetHeight + TOOLTIP_TARGET_GAP;
+
+  const fitsAbove = aboveTop >= TOOLTIP_EDGE_MARGIN;
+  const fitsBelow =
+    belowTop + tooltipHeight <= screenHeight - TOOLTIP_EDGE_MARGIN;
+
+  if (shouldPlaceAbove && fitsAbove) return aboveTop;
+  if (!shouldPlaceAbove && fitsBelow) return belowTop;
+  if (fitsBelow) return belowTop;
+  if (fitsAbove) return aboveTop;
+
+  // Neither side fits: center vertically within the viewport.
+  return Math.max(TOOLTIP_EDGE_MARGIN, (screenHeight - tooltipHeight) / 2);
+};


### PR DESCRIPTION
## Summary

When the highlighted element is too tall to leave room for the tooltip above
or below it, the tooltip was placed below the target and rendered off-screen,
getting cut off at the bottom of the viewport.

## Root cause

In `TourTooltip`, the placement logic only decided **above vs. below** via the
`shouldPlaceAbove` heuristic, but never checked whether the chosen side
actually fits within the screen bounds:

```ts
style.top = safeTargetY + safeTargetHeight + 20; // no overflow check
```

With a tall target near the top of the screen (e.g. a 400px feed card on a
small phone), neither `spaceAbove` nor `spaceBelow` fits the tooltip, so the
"below" position lands past the bottom edge of the screen.

## Fix

Placement math extracted into a pure, worklet-compatible helper
(`getTooltipTop` in `src/utils/tooltipPlacement.ts`) with a clear priority:

1. The side chosen by the existing above/below heuristic (unchanged).
2. The opposite side, if the preferred one would overflow the viewport.
3. Vertically centered on screen when neither side fits, clamped to a 12px
   edge margin.

## Screenshots

| Before | After |
| ------ | ----- |
| Tooltip cut off at bottom <img width="359" height="640" alt="image" src="https://github.com/user-attachments/assets/74326a25-9a7e-42ce-8111-c6b404e57e57" /> | Tooltip centered, fully visible <img width="359" height="640" alt="lumen-step5-fixed" src="https://github.com/user-attachments/assets/086d8b41-152f-4d32-8bd2-98c24416d147" /> |

<!-- attach before/after screenshots here -->

## Testing

- Added unit tests for the placement helper covering: below placement, above
  placement, the tall-target fallback, viewport containment when centered, and
  opposite-side fallback (`yarn test`).
- `yarn typecheck` and `yarn lint` pass.
- Verified manually in the example app (Android emulator, 360x640dp): a 400px
  post card step now shows the tooltip centered and fully visible; normal
  above/below placements (header icon, FAB, stats card) are unchanged.
