### PR TITLE
Feat/follow target

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -52,6 +52,8 @@ export default function App() {
               // Persistence - saves progress to storage (MMKV or AsyncStorage)
               persistence: persistenceConfig,
               preventInteraction: false,
+              // followTarget - zone and tooltip track the target while scrolling
+              followTarget: true,
               // enableGlow - enable/disable glow effect for all steps (can still be overridden per-step)
               enableGlow: false,
             }}

--- a/src/__tests__/tooltipPlacement.test.ts
+++ b/src/__tests__/tooltipPlacement.test.ts
@@ -60,4 +60,18 @@ describe('getTooltipTop', () => {
     const top = getTooltipTop(250, 360, 120, SCREEN_HEIGHT);
     expect(top).toBe(250 - 120 - TOOLTIP_TARGET_GAP);
   });
+
+  it('centers the tooltip when the target is scrolled fully above the viewport', () => {
+    // With followTarget enabled the zone follows the element off-screen;
+    // the tooltip must stay visible instead of being dragged off with it.
+    const top = getTooltipTop(-500, 400, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe((SCREEN_HEIGHT - TOOLTIP_HEIGHT) / 2);
+  });
+
+  it('centers the tooltip when the target is scrolled fully below the viewport', () => {
+    // aboveTop would be 500: it starts on-screen but the tooltip's bottom
+    // edge (500+180=680) overflows, so "above" must not count as fitting.
+    const top = getTooltipTop(700, 400, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe((SCREEN_HEIGHT - TOOLTIP_HEIGHT) / 2);
+  });
 });

--- a/src/__tests__/tooltipPlacement.test.ts
+++ b/src/__tests__/tooltipPlacement.test.ts
@@ -1,0 +1,63 @@
+import {
+  getTooltipTop,
+  TOOLTIP_EDGE_MARGIN,
+  TOOLTIP_TARGET_GAP,
+} from '../utils/tooltipPlacement';
+
+const SCREEN_HEIGHT = 640;
+const TOOLTIP_HEIGHT = 180;
+
+describe('getTooltipTop', () => {
+  it('places the tooltip below a target near the top of the screen', () => {
+    // Header icon: plenty of room below.
+    const top = getTooltipTop(40, 44, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe(40 + 44 + TOOLTIP_TARGET_GAP);
+  });
+
+  it('places the tooltip above a target near the bottom of the screen', () => {
+    // FAB: plenty of room above.
+    const top = getTooltipTop(560, 56, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBe(560 - TOOLTIP_HEIGHT - TOOLTIP_TARGET_GAP);
+  });
+
+  it('centers the tooltip on screen when the target is too tall for either side', () => {
+    // The reported bug: a 400px tall card starting near the top leaves
+    // no room above or below, so the tooltip rendered off-screen bottom.
+    const targetY = 143;
+    const targetHeight = 400;
+
+    // Sanity check: both sides genuinely overflow in this setup.
+    expect(targetY - TOOLTIP_HEIGHT - TOOLTIP_TARGET_GAP).toBeLessThan(
+      TOOLTIP_EDGE_MARGIN
+    );
+    expect(
+      targetY + targetHeight + TOOLTIP_TARGET_GAP + TOOLTIP_HEIGHT
+    ).toBeGreaterThan(SCREEN_HEIGHT - TOOLTIP_EDGE_MARGIN);
+
+    const top = getTooltipTop(
+      targetY,
+      targetHeight,
+      TOOLTIP_HEIGHT,
+      SCREEN_HEIGHT
+    );
+    expect(top).toBe((SCREEN_HEIGHT - TOOLTIP_HEIGHT) / 2);
+  });
+
+  it('keeps the tooltip fully inside the viewport when centered', () => {
+    const top = getTooltipTop(143, 400, TOOLTIP_HEIGHT, SCREEN_HEIGHT);
+    expect(top).toBeGreaterThanOrEqual(TOOLTIP_EDGE_MARGIN);
+    expect(top + TOOLTIP_HEIGHT).toBeLessThanOrEqual(
+      SCREEN_HEIGHT - TOOLTIP_EDGE_MARGIN
+    );
+  });
+
+  it('falls back to the opposite side when the preferred side overflows', () => {
+    // Heuristic wants "below" (target top-half) but below overflows while
+    // above fits: target lower than usual with a small tooltip.
+    // targetY=250, height=200, tooltip=120 on 640 screen:
+    // below top = 470, 470+120=590 <= 628 fits... so force overflow:
+    // targetY=250, height=360 → below top = 630 → overflow; above top = 110 → fits.
+    const top = getTooltipTop(250, 360, 120, SCREEN_HEIGHT);
+    expect(top).toBe(250 - 120 - TOOLTIP_TARGET_GAP);
+  });
+});

--- a/src/components/TourProvider.tsx
+++ b/src/components/TourProvider.tsx
@@ -247,6 +247,12 @@ export const TourProvider: React.FC<TourProviderProps> = ({
   const targetRadius = useSharedValue(10); // Default border radius
   const opacity = useSharedValue(0); // 0 = hidden, 1 = visible
   const zoneBorderWidth = useSharedValue(DEFAULT_ZONE_STYLE.borderWidth);
+  // Scroll offset of the registered ScrollView (UI-thread updated).
+  // Drives 60fps followTarget tracking in TourZone.
+  const scrollOffsetY = useSharedValue(0);
+  const followBaseTargetY = useSharedValue(0);
+  const followBaseScrollY = useSharedValue(0);
+  const followTargetActive = useSharedValue(false);
 
   // Track current step's resolved zone style
   const currentZoneStyle = useMemo<ZoneStyle | null>(() => {
@@ -648,6 +654,10 @@ export const TourProvider: React.FC<TourProviderProps> = ({
       targetRadius,
       opacity,
       zoneBorderWidth,
+      scrollOffsetY,
+      followBaseTargetY,
+      followBaseScrollY,
+      followTargetActive,
       steps,
       config,
       containerRef,
@@ -678,6 +688,10 @@ export const TourProvider: React.FC<TourProviderProps> = ({
       targetRadius,
       opacity,
       zoneBorderWidth,
+      scrollOffsetY,
+      followBaseTargetY,
+      followBaseScrollY,
+      followTargetActive,
       steps,
       config,
       containerRef,

--- a/src/components/TourTooltip.tsx
+++ b/src/components/TourTooltip.tsx
@@ -19,6 +19,7 @@ import type {
   TooltipStyles,
 } from '../types';
 import { DEFAULT_LABELS } from '../constants/defaults';
+import { getTooltipTop } from '../utils/tooltipPlacement';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
@@ -135,13 +136,6 @@ export const TourTooltip = memo(() => {
       Extrapolation.CLAMP
     );
 
-    const spaceAbove = safeTargetY;
-    const spaceBelow = SCREEN_HEIGHT - (safeTargetY + safeTargetHeight);
-
-    const shouldPlaceAbove =
-      (spaceAbove > spaceBelow && spaceAbove > safeTooltipHeight + 30) ||
-      (safeTargetY > SCREEN_HEIGHT / 2 && spaceAbove > safeTooltipHeight + 20);
-
     const horizontalCenter = safeTargetX + safeTargetWidth / 2;
     const left = horizontalCenter - tooltipWidth / 2;
 
@@ -159,13 +153,13 @@ export const TourTooltip = memo(() => {
       transform: [{ translateY: interpolate(activeOpacity, [0, 1], [10, 0]) }],
     };
 
-    if (shouldPlaceAbove) {
-      style.top = Math.max(10, safeTargetY - safeTooltipHeight - 20);
-      style.bottom = undefined;
-    } else {
-      style.top = safeTargetY + safeTargetHeight + 20;
-      style.bottom = undefined;
-    }
+    style.top = getTooltipTop(
+      safeTargetY,
+      safeTargetHeight,
+      safeTooltipHeight,
+      SCREEN_HEIGHT
+    );
+    style.bottom = undefined;
 
     return style;
   });

--- a/src/components/TourZone.tsx
+++ b/src/components/TourZone.tsx
@@ -25,6 +25,7 @@ import type {
   ZoneShape,
   CardProps,
 } from '../types';
+import { computeZoneFrame } from '../utils/zoneGeometry';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('screen');
 
@@ -108,6 +109,7 @@ export const TourZone: React.FC<TourZoneProps> = ({
 
   const viewRef = useAnimatedRef<any>();
   const isActive = currentStep === stepKey;
+  const followTarget = config?.followTarget === true;
 
   const isScrolling = useSharedValue(false);
   const isScrollingRef = useRef(false);
@@ -469,7 +471,8 @@ export const TourZone: React.FC<TourZoneProps> = ({
   // because the new closure has to be (re)processed during render.
   const frameWorklet = useCallback(() => {
     'worklet';
-    if (!isActive || isScrolling.value) {
+    // When followTarget is enabled, the JS-side follow poll owns tracking.
+    if (!isActive || isScrolling.value || followTarget) {
       return;
     }
     try {
@@ -495,45 +498,20 @@ export const TourZone: React.FC<TourZoneProps> = ({
             stiffness: 100,
           };
 
-          const zpt =
-            resolvedZoneStyle.paddingTop ?? resolvedZoneStyle.padding ?? 0;
-          const zpr =
-            resolvedZoneStyle.paddingRight ?? resolvedZoneStyle.padding ?? 0;
-          const zpb =
-            resolvedZoneStyle.paddingBottom ?? resolvedZoneStyle.padding ?? 0;
-          const zpl =
-            resolvedZoneStyle.paddingLeft ?? resolvedZoneStyle.padding ?? 0;
-          const zShape = resolvedZoneStyle.shape ?? 'rounded-rect';
+          const frame = computeZoneFrame(
+            x,
+            y,
+            width,
+            height,
+            resolvedZoneStyle,
+            borderRadius
+          );
 
-          let sx = x - zpl;
-          let sy = y - zpt;
-          let sw = width + zpl + zpr;
-          let sh = height + zpt + zpb;
-          let sr = borderRadius;
-
-          if (zShape === 'circle') {
-            const cx = x + width / 2;
-            const cy = y + height / 2;
-            const radius =
-              Math.max(width, height) / 2 + (resolvedZoneStyle.padding ?? 0);
-            sx = cx - radius;
-            sy = cy - radius;
-            sw = radius * 2;
-            sh = radius * 2;
-            sr = radius;
-          } else if (zShape === 'pill') {
-            sx = x - zpl;
-            sy = y - zpt;
-            sw = width + zpl + zpr;
-            sh = height + zpt + zpb;
-            sr = sh / 2;
-          }
-
-          targetX.value = withSpring(sx, springConfig);
-          targetY.value = withSpring(sy, springConfig);
-          targetWidth.value = withSpring(sw, springConfig);
-          targetHeight.value = withSpring(sh, springConfig);
-          targetRadius.value = withSpring(sr, springConfig);
+          targetX.value = withSpring(frame.x, springConfig);
+          targetY.value = withSpring(frame.y, springConfig);
+          targetWidth.value = withSpring(frame.width, springConfig);
+          targetHeight.value = withSpring(frame.height, springConfig);
+          targetRadius.value = withSpring(frame.radius, springConfig);
         }
       }
     } catch {
@@ -546,6 +524,7 @@ export const TourZone: React.FC<TourZoneProps> = ({
   }, [
     isActive,
     isScrolling,
+    followTarget,
     viewRef,
     containerRef,
     config,
@@ -554,6 +533,103 @@ export const TourZone: React.FC<TourZoneProps> = ({
   ]);
 
   useFrameCallback(frameWorklet, isActive);
+
+  // Follow mode: poll the element position on the JS thread so the zone and
+  // tooltip track user scrolls and any layout movement. The UI-thread frame
+  // callback above is disabled while this owns tracking.
+  useEffect(() => {
+    if (!isActive || !followTarget) return;
+
+    // NaN baseline: the first poll only records the position, so in-flight
+    // step transition springs are never interrupted.
+    let lastX = NaN;
+    let lastY = NaN;
+    let lastW = NaN;
+    let lastH = NaN;
+
+    const poll = () => {
+      // The orchestrated scroll/transition pipeline owns the position.
+      if (isScrollingRef.current) return;
+
+      const view = viewRef.current as any;
+      const container = containerRef.current as any;
+      if (!view || !container) return;
+
+      view.measure(
+        (
+          _x: number,
+          _y: number,
+          width: number,
+          height: number,
+          pageX: number,
+          pageY: number
+        ) => {
+          if (width <= 0 || height <= 0 || isNaN(pageX) || isNaN(pageY)) {
+            return;
+          }
+          container.measure(
+            (
+              _cx: number,
+              _cy: number,
+              _cw: number,
+              _ch: number,
+              containerPageX: number,
+              containerPageY: number
+            ) => {
+              const x = pageX - containerPageX;
+              const y = pageY - containerPageY;
+
+              const moved =
+                Math.abs(x - lastX) > 0.5 ||
+                Math.abs(y - lastY) > 0.5 ||
+                Math.abs(width - lastW) > 0.5 ||
+                Math.abs(height - lastH) > 0.5;
+
+              lastX = x;
+              lastY = y;
+              lastW = width;
+              lastH = height;
+
+              // Only write when the element actually moved.
+              if (!moved) return;
+
+              const frame = computeZoneFrame(
+                x,
+                y,
+                width,
+                height,
+                resolvedZoneStyle,
+                borderRadius
+              );
+
+              // Direct assignment (no spring): tracking stays 1:1
+              // with the element.
+              targetX.value = frame.x;
+              targetY.value = frame.y;
+              targetWidth.value = frame.width;
+              targetHeight.value = frame.height;
+              targetRadius.value = frame.radius;
+            }
+          );
+        }
+      );
+    };
+
+    const intervalId = setInterval(poll, 50);
+    return () => clearInterval(intervalId);
+  }, [
+    isActive,
+    followTarget,
+    viewRef,
+    containerRef,
+    resolvedZoneStyle,
+    borderRadius,
+    targetX,
+    targetY,
+    targetWidth,
+    targetHeight,
+    targetRadius,
+  ]);
 
   // Sync position if the element physically resizes, but strictly avoid
   // measuring if we are currently handling an orchestrated scroll.

--- a/src/components/TourZone.tsx
+++ b/src/components/TourZone.tsx
@@ -100,6 +100,10 @@ export const TourZone: React.FC<TourZoneProps> = ({
     targetWidth,
     targetHeight,
     targetRadius,
+    scrollOffsetY,
+    followBaseTargetY,
+    followBaseScrollY,
+    followTargetActive,
     config,
     registerScrollEndCallback,
     unregisterScrollEndCallback,
@@ -166,8 +170,9 @@ export const TourZone: React.FC<TourZoneProps> = ({
   useLayoutEffect(() => {
     if (isActive) {
       setIsScrolling(true);
+      followTargetActive.value = false;
     }
-  }, [isActive, setIsScrolling]);
+  }, [isActive, setIsScrolling, followTargetActive]);
 
   // Reads the element's final screen position and updates the overlay.
   // onComplete fires after updateStepLayout succeeds — used to fade back in
@@ -534,9 +539,9 @@ export const TourZone: React.FC<TourZoneProps> = ({
 
   useFrameCallback(frameWorklet, isActive);
 
-  // Follow mode: poll the element position on the JS thread so the zone and
-  // tooltip track user scrolls and any layout movement. The UI-thread frame
-  // callback above is disabled while this owns tracking.
+  // Follow mode: the JS thread periodically re-anchors the element's accurate
+  // screen position. Scroll movement between anchors is handled below on the
+  // UI thread from the live scroll offset, avoiding 20Hz visual steps.
   useEffect(() => {
     if (!isActive || !followTarget) return;
 
@@ -590,7 +595,8 @@ export const TourZone: React.FC<TourZoneProps> = ({
               lastW = width;
               lastH = height;
 
-              // Only write when the element actually moved.
+              // Only re-anchor after real movement. Skipping the first poll
+              // lets the normal step-transition spring finish uninterrupted.
               if (!moved) return;
 
               const frame = computeZoneFrame(
@@ -602,13 +608,15 @@ export const TourZone: React.FC<TourZoneProps> = ({
                 borderRadius
               );
 
-              // Direct assignment (no spring): tracking stays 1:1
-              // with the element.
               targetX.value = frame.x;
               targetY.value = frame.y;
               targetWidth.value = frame.width;
               targetHeight.value = frame.height;
               targetRadius.value = frame.radius;
+
+              followBaseTargetY.value = frame.y;
+              followBaseScrollY.value = scrollOffsetY.value;
+              followTargetActive.value = true;
             }
           );
         }
@@ -629,6 +637,10 @@ export const TourZone: React.FC<TourZoneProps> = ({
     targetWidth,
     targetHeight,
     targetRadius,
+    followBaseTargetY,
+    followBaseScrollY,
+    followTargetActive,
+    scrollOffsetY,
   ]);
 
   // Sync position if the element physically resizes, but strictly avoid

--- a/src/hooks/useTourScrollView.ts
+++ b/src/hooks/useTourScrollView.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { useAnimatedScrollHandler } from 'react-native-reanimated';
 import { useTour } from './useTour';
 
 export interface TourScrollViewOptions {
@@ -41,10 +42,13 @@ export interface TourScrollViewResult {
   onMomentumScrollEnd: () => void;
   /**
    * Props to spread onto your ScrollView for full tour integration.
-   * Includes ref, onMomentumScrollEnd, and scrollEnabled (if disableScrollDuringTour is true).
+   * Includes ref, onMomentumScrollEnd, followTarget's animated onScroll
+   * handler, and scrollEnabled (if disableScrollDuringTour is true).
    */
   scrollViewProps: {
     ref: React.RefObject<any>;
+    onScroll?: (event: any) => void;
+    scrollEventThrottle?: number;
     onMomentumScrollEnd: () => void;
     scrollEnabled?: boolean;
   };
@@ -80,10 +84,29 @@ export function useTourScrollView(
 
   // Get the tour context - use type assertion since we know the internal structure
   const tour = useTour();
-  const { scrollViewRef, currentStep, triggerScrollEnd } = tour as any;
+  const {
+    scrollViewRef,
+    currentStep,
+    triggerScrollEnd,
+    scrollOffsetY,
+    targetY,
+    followBaseTargetY,
+    followBaseScrollY,
+    followTargetActive,
+    config,
+  } = tour as any;
 
   const isTourActive = currentStep !== null;
   const scrollEnabled = disableScrollDuringTour ? !isTourActive : true;
+  const followTarget = config?.followTarget === true;
+
+  const onScroll = useAnimatedScrollHandler((event) => {
+    const y = event.contentOffset.y;
+    scrollOffsetY.value = y;
+    if (followTargetActive.value) {
+      targetY.value = followBaseTargetY.value - (y - followBaseScrollY.value);
+    }
+  });
 
   const scrollTo = useCallback(
     (opts: { x?: number; y?: number; animated?: boolean }) => {
@@ -105,17 +128,30 @@ export function useTourScrollView(
   const scrollViewProps = useMemo(() => {
     const props: {
       ref: React.RefObject<any>;
+      onScroll?: (event: any) => void;
+      scrollEventThrottle?: number;
       onMomentumScrollEnd: () => void;
       scrollEnabled?: boolean;
     } = {
       ref: scrollViewRef,
       onMomentumScrollEnd: triggerScrollEnd,
     };
+    if (followTarget) {
+      props.onScroll = onScroll;
+      props.scrollEventThrottle = 16;
+    }
     if (disableScrollDuringTour) {
       props.scrollEnabled = scrollEnabled;
     }
     return props;
-  }, [scrollViewRef, triggerScrollEnd, disableScrollDuringTour, scrollEnabled]);
+  }, [
+    scrollViewRef,
+    triggerScrollEnd,
+    followTarget,
+    onScroll,
+    disableScrollDuringTour,
+    scrollEnabled,
+  ]);
 
   return {
     scrollViewRef,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -360,6 +360,9 @@ export interface TourConfig {
    * element: when the user scrolls, or when the element moves/resizes for any
    * reason while its step is active.
    *
+   * For frame-rate scroll tracking, spread `scrollViewProps` from
+   * `useTourScrollView()` onto an `Animated.ScrollView`.
+   *
    * When false (default), the zone is positioned once when the step activates
    * and stays there until the next step.
    * @default false
@@ -453,6 +456,18 @@ export interface InternalTourContextType extends TourContextType {
   targetHeight: SharedValue<number>;
   targetRadius: SharedValue<number>;
   opacity: SharedValue<number>;
+  /**
+   * Vertical scroll offset of the registered ScrollView, updated on the UI
+   * thread by the animated onScroll handler wired in useTourScrollView.
+   * Used for 60fps followTarget tracking. Stays 0 when unwired.
+   */
+  scrollOffsetY: SharedValue<number>;
+  /** Base zone Y captured by TourZone for smooth scroll-delta tracking. */
+  followBaseTargetY: SharedValue<number>;
+  /** Scroll offset paired with followBaseTargetY. */
+  followBaseScrollY: SharedValue<number>;
+  /** Whether the animated onScroll handler currently owns targetY. */
+  followTargetActive: SharedValue<boolean>;
   /** Border width for the zone glow ring */
   zoneBorderWidth: SharedValue<number>;
   containerRef: React.RefObject<any>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -355,6 +355,16 @@ export interface TourConfig {
    * @default false
    */
   enableGlow?: boolean;
+  /**
+   * If true, the highlight zone and tooltip continuously follow the target
+   * element: when the user scrolls, or when the element moves/resizes for any
+   * reason while its step is active.
+   *
+   * When false (default), the zone is positioned once when the step activates
+   * and stays there until the next step.
+   * @default false
+   */
+  followTarget?: boolean;
 }
 
 export interface TourContextType {

--- a/src/utils/tooltipPlacement.ts
+++ b/src/utils/tooltipPlacement.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure placement math for the tour tooltip.
+ * Kept separate from TourTooltip so it can be unit-tested
+ * and called from the Reanimated worklet (hence the 'worklet' directive).
+ */
+
+/** Minimum distance from the screen edges. */
+export const TOOLTIP_EDGE_MARGIN = 12;
+/** Vertical gap between the highlighted target and the tooltip. */
+export const TOOLTIP_TARGET_GAP = 20;
+
+/**
+ * Computes the `top` position for the tooltip.
+ *
+ * Preference order:
+ * 1. The side (above/below the target) chosen by the existing heuristic.
+ * 2. The opposite side, if the preferred side would overflow the viewport.
+ * 3. Vertically centered on screen, when neither side fits
+ *    (e.g. the highlighted element is too tall and there is no room
+ *    above or below without rendering off-screen).
+ */
+export const getTooltipTop = (
+  targetY: number,
+  targetHeight: number,
+  tooltipHeight: number,
+  screenHeight: number
+): number => {
+  'worklet';
+
+  const spaceAbove = targetY;
+  const spaceBelow = screenHeight - (targetY + targetHeight);
+
+  const shouldPlaceAbove =
+    (spaceAbove > spaceBelow && spaceAbove > tooltipHeight + 30) ||
+    (targetY > screenHeight / 2 && spaceAbove > tooltipHeight + 20);
+
+  const aboveTop = targetY - tooltipHeight - TOOLTIP_TARGET_GAP;
+  const belowTop = targetY + targetHeight + TOOLTIP_TARGET_GAP;
+
+  const fitsAbove = aboveTop >= TOOLTIP_EDGE_MARGIN;
+  const fitsBelow =
+    belowTop + tooltipHeight <= screenHeight - TOOLTIP_EDGE_MARGIN;
+
+  if (shouldPlaceAbove && fitsAbove) return aboveTop;
+  if (!shouldPlaceAbove && fitsBelow) return belowTop;
+  if (fitsBelow) return belowTop;
+  if (fitsAbove) return aboveTop;
+
+  // Neither side fits: center vertically within the viewport.
+  return Math.max(TOOLTIP_EDGE_MARGIN, (screenHeight - tooltipHeight) / 2);
+};

--- a/src/utils/tooltipPlacement.ts
+++ b/src/utils/tooltipPlacement.ts
@@ -37,8 +37,13 @@ export const getTooltipTop = (
   const aboveTop = targetY - tooltipHeight - TOOLTIP_TARGET_GAP;
   const belowTop = targetY + targetHeight + TOOLTIP_TARGET_GAP;
 
-  const fitsAbove = aboveTop >= TOOLTIP_EDGE_MARGIN;
+  // A side only fits if the ENTIRE tooltip rect stays inside the viewport.
+  // (A target scrolled off-screen must not drag the tooltip off with it.)
+  const fitsAbove =
+    aboveTop >= TOOLTIP_EDGE_MARGIN &&
+    aboveTop + tooltipHeight <= screenHeight - TOOLTIP_EDGE_MARGIN;
   const fitsBelow =
+    belowTop >= TOOLTIP_EDGE_MARGIN &&
     belowTop + tooltipHeight <= screenHeight - TOOLTIP_EDGE_MARGIN;
 
   if (shouldPlaceAbove && fitsAbove) return aboveTop;

--- a/src/utils/zoneGeometry.ts
+++ b/src/utils/zoneGeometry.ts
@@ -1,0 +1,60 @@
+import type { ZoneStyle } from '../types';
+
+export interface ZoneFrame {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  radius: number;
+}
+
+/**
+ * Computes the highlight zone frame for an element, applying per-side padding
+ * and the zone shape. Worklet-safe so it can run on the UI thread.
+ *
+ * Unlike TourProvider's computeZoneGeometry, this does NOT clamp to screen
+ * bounds: tracking must be able to follow the element off-viewport.
+ */
+export const computeZoneFrame = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  zoneStyle: ZoneStyle,
+  borderRadius: number
+): ZoneFrame => {
+  'worklet';
+
+  const zpt = zoneStyle.paddingTop ?? zoneStyle.padding ?? 0;
+  const zpr = zoneStyle.paddingRight ?? zoneStyle.padding ?? 0;
+  const zpb = zoneStyle.paddingBottom ?? zoneStyle.padding ?? 0;
+  const zpl = zoneStyle.paddingLeft ?? zoneStyle.padding ?? 0;
+  const zShape = zoneStyle.shape ?? 'rounded-rect';
+
+  if (zShape === 'circle') {
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+    const radius = Math.max(width, height) / 2 + (zoneStyle.padding ?? 0);
+    return {
+      x: cx - radius,
+      y: cy - radius,
+      width: radius * 2,
+      height: radius * 2,
+      radius,
+    };
+  }
+
+  if (zShape === 'pill') {
+    const w = width + zpl + zpr;
+    const h = height + zpt + zpb;
+    return { x: x - zpl, y: y - zpt, width: w, height: h, radius: h / 2 };
+  }
+
+  return {
+    x: x - zpl,
+    y: y - zpt,
+    width: width + zpl + zpr,
+    height: height + zpt + zpb,
+    radius: borderRadius,
+  };
+};

--- a/website/docs/api/tour-provider.md
+++ b/website/docs/api/tour-provider.md
@@ -43,6 +43,7 @@ interface TourConfig {
   persistence?: TourPersistenceConfig;
   enableGlow?: boolean;
   tooltipStyles?: TooltipStyles;
+  followTarget?: boolean;
 }
 ```
 
@@ -57,6 +58,7 @@ interface TourConfig {
 | `persistence`        | `TourPersistenceConfig`           | `undefined` | Configuration for saving and resuming tour progress.                                 |
 | `enableGlow`         | `boolean`                         | `false`     | Enables the glow effect around highlighted zones.                                    |
 | `tooltipStyles`      | `TooltipStyles`                   | `undefined` | Custom styles for the default tooltip card.                                          |
+| `followTarget`       | `boolean`                         | `false`     | If `true`, the zone and tooltip follow the target when the user scrolls or it moves. |
 
 ## Animation Presets
 


### PR DESCRIPTION
## Summary

When `followTarget` is enabled, the tour highlight zone and tooltip now track
the target element while the user scrolls or when the element otherwise moves
on screen.

## Root cause

Previously the zone was positioned once when a step activated and never
updated during user scrolling. The existing UI-thread `measure()` loop in
`TourZone` silently failed in this environment, so the zone stayed at stale
coordinates once content moved.

## Fix

- Added a new `followTarget?: boolean` option to `TourConfig`.
- `useTourScrollView()` wires an animated `onScroll` handler that feeds the
  live scroll offset to the tour context.
- When `followTarget` is true, `TourZone` arms a JS-side measurement poll that
  re-anchors the accurate target position.
- The animated scroll handler updates `targetY` directly on the UI thread at
  native frame rate, so the zone follows scrolls smoothly instead of jumping
  every 50ms.
- Tooltip placement was hardened so that targets scrolled fully off-screen
  center the tooltip instead of dragging it off the viewport.

## Screenshots

| Before | After |
| ------ | ----- |
| Zone stays behind while target scrolls away | Zone follows target smoothly |

### Before

https://github.com/user-attachments/assets/a4dc7269-e44f-45ca-8496-26cf57f4872f

### After

https://github.com/user-attachments/assets/e01ba607-de8a-4f04-9eca-5df9c8fbec96

## Testing

- `yarn typecheck` and `yarn lint` pass.
- `yarn test` passes (tooltip placement tests extended for off-screen
  targets).
- Verified in the example app on Android emulator:
  - Enabled `followTarget: true` in `example/src/App.tsx`.
  - At step 5 (Sarah Jenkins post), scrolling up moves the highlight zone
    with the card and the tooltip tracks/recenters correctly.
  - Scrolling back down re-attaches the zone around the target.
  - Step transitions (e.g. 5 → 6 Stats Overview) still auto-scroll and land
    correctly.

## Usage

```tsx
<TourProvider stepsOrder={stepsOrder} config={{ followTarget: true }}>
  <YourApp />
</TourProvider>
```

For smoothest tracking, spread `scrollViewProps` from `useTourScrollView()`
onto an `Animated.ScrollView`:

```tsx
const { scrollViewProps } = useTourScrollView();
return <Animated.ScrollView {...scrollViewProps}>{children}</Animated.ScrollView>;
```
